### PR TITLE
Fixed pokemon_spec to now state right requirements

### DIFF
--- a/spec/pokemon_spec.rb
+++ b/spec/pokemon_spec.rb
@@ -11,7 +11,7 @@ describe "Pokemon" do
   let(:pokemon) {Pokemon.new(1, "Pikachu", "fire", @db)}
 
   describe ".initialize" do
-    it 'is initialized with a name, type and db' do
+    it 'is initialized with an id, name, type and db' do
       expect(pokemon).to respond_to(:id)
       expect(pokemon).to respond_to(:name)
       expect(pokemon).to respond_to(:type)


### PR DESCRIPTION
This test stated that it wanted a new Pokemon to initialize with a name, type and db, but the test was passing 4 arguments(they were passing an ID integer) instead of 3. Updated so now they know to initialize the class with an id, name, type and db.

@AnnJohn @PeterBell 
